### PR TITLE
Feature: Added Toggle Comment Borders

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ into something like this:
 # ██   ██ ███████ ███████ ███████  ██████       ███ ███   ██████  ██   ██ ███████ ██████
 ```
 
+you can also `Toggle Comment Borders` to put a border around the text to add more distinction in the minimap:
+
+```
+###############################################################################
+# ██   ██ ███████ ██      ██       ██████      ██     ██  ██████  ██████  ██      ██████
+# ██   ██ ██      ██      ██      ██    ██     ██     ██ ██    ██ ██   ██ ██      ██   ██
+# ███████ █████   ██      ██      ██    ██     ██  █  ██ ██    ██ ██████  ██      ██   ██
+# ██   ██ ██      ██      ██      ██    ██     ██ ███ ██ ██    ██ ██   ██ ██      ██   ██
+# ██   ██ ███████ ███████ ███████  ██████       ███ ███   ██████  ██   ██ ███████ ██████
+###############################################################################
+```
+
+Note that `Toggle Comment Borders` determines border size based on your editors preferred line length, Atom's default is 80 as shown above.
+
 ## Usage
 To convert text, select the text you wish to convert, and do **any** of the following:
 - Press `ctrl-shift-del` **or**

--- a/README.md
+++ b/README.md
@@ -30,8 +30,12 @@ into something like this:
 To convert text, select the text you wish to convert, and do **any** of the following:
 - Press `ctrl-shift-del` **or**
 - Select `Minimap Titles: Convert` in the [command palette](https://atom.io/docs/latest/getting-started-atom-basics#command-palette) **or**
-- Select _Packages_ -> _Minimap Titles Convert_ from the main menu **or**
+- Select _Packages_ -> _Minimap Titles_ -> _Convert_ from the main menu **or**
 - Right click on the selected text, and select _Minimap Titles: Convert_ from the context menu
+
+To create comment borders around text to help distinguish sections in the minimap do the following:
+- Select _Packages_ -> _Minimap Titles_ -> _Toggle Comment Borders_ from the main menu
+- Run the Convert command on your text as detailed above
 
 ## Credits
 Based on the following packages:

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ you can also `Toggle Comment Borders` to put a border around the text to add mor
 
 Note that `Toggle Comment Borders` determines border size based on your editors preferred line length, Atom's default is 80 as shown above.
 
+The difference is slight and completely based on user preference:
+
+<img src="http://i.imgur.com/xBCmrSx.png" alt="Border vs. No Border Example">
+
 ## Usage
 To convert text, select the text you wish to convert, and do **any** of the following:
 - Press `ctrl-shift-del` **or**

--- a/lib/minimap-titles.coffee
+++ b/lib/minimap-titles.coffee
@@ -55,29 +55,30 @@ module.exports = MinimapTitles =
                 when 'sh','yaml',''
                   commentStart = ''
                   commentEnd = ''
+                  commentRepeat = 80
                   # add '# ' to the beginning of each line
                   art = art.replace /^/, "# "
                   art = art.replace /\n/g, "\n# "
 
                 when 'coffee', 'cjsx', 'cson'
-                  commentStart = '###\n'
-                  commentEnd = '\n###'
+                  commentStart = '###\n' + Array(commentRepeat).join('#') + '\n'
+                  commentEnd = Array(commentRepeat).join('#') +'\n###\n'
 
                 when 'html','md'
-                  commentStart = '<!--\n'
-                  commentEnd = '\n-->'
+                  commentStart = '<!--' + Array(commentRepeat-4).join('-') + '\n' 
+                  commentEnd = Array(commentRepeat-3).join('-') +'\n-->'
 
                 when 'php'
-                  commentStart = '/**\n
+                  commentStart = '/**' + Array(commentRepeat-3).join('*') + '\n
                   \t * Block comment\n
                   \t *\n
                   \t * @param type\n
                   \t * @return void\n'
-                  commentEnd = '\t */\n\t'
+                  commentEnd = Array(commentRepeat-2).join('*') + '*/\n\t'
 
                 else
-                  commentStart = '/*\n'
-                  commentEnd = '\n*/'
+                  commentStart = '/*' + Array(commentRepeat-2).join('*') + '\n'
+                  commentEnd = '\n' + Array(commentRepeat-2).join('*') + '*/\n'
 
               selection.insertText(
                 "#{commentStart+art+commentEnd}\n",

--- a/menus/minimap-titles.cson
+++ b/menus/minimap-titles.cson
@@ -13,7 +13,7 @@
         'label': 'Minimap Titles'
         'submenu': [
               {
-                'label': 'Minimap Titles Convert'
+                'label': 'Convert'
                 'command': 'minimap-titles:convert'
               }
               {

--- a/menus/minimap-titles.cson
+++ b/menus/minimap-titles.cson
@@ -10,10 +10,18 @@
   {
     'label': 'Packages'
     'submenu': [
-      {
-        'label': 'Minimap Titles Convert'
-        'command': 'minimap-titles:convert'
-      }
+        'label': 'Minimap Titles'
+        'submenu': [
+              {
+                'label': 'Minimap Titles Convert'
+                'command': 'minimap-titles:convert'
+              }
+              {
+                'label': 'Toggle Comment Borders'
+                'command': 'minimap-titles:border'
+              }
+        ]
     ]
   }
 ]
+


### PR DESCRIPTION
Hey! I added a new feature to your package to toggle comment borders, you can view the updated README to get an example of what the change is.

In essence
- Border On property set by default to false (normal behavior of your package)
- Menu -> Minimap Titles -> Toggle Comment Borders to change property to true
  - Property pulls default preferredLineLength set in atom editor and adds a comment block line stretching the length of the editor's preferredLineLength at the top and bottom of the ascii art

I tested every switch case and all the stuff looked good
