### PR TITLE
Adding support for custom font

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ To create comment borders around text to help distinguish sections in the minima
 - Select _Packages_ -> _Minimap Titles_ -> _Toggle Comment Borders_ from the main menu
 - Run the Convert command on your text as detailed above
 
+To set a custom font, set `atom-minimap-titles.font` in your atom config file, as such:
+```
+"atom-minimap-titles":
+  font: "Colossal"
+```
+See existing fonts in the [figlet font database](http://www.figlet.org/fontdb.cgi).
+
 ## Credits
 Based on the following packages:
 - [atom-figletify](https://github.com/robatron/atom-figletify)

--- a/lib/minimap-titles.coffee
+++ b/lib/minimap-titles.coffee
@@ -15,6 +15,8 @@ module.exports = MinimapTitles =
     @subscriptions.add atom.commands.add 'atom-workspace', 'minimap-titles:convert': => @convert()
     @subscriptions.add atom.commands.add 'atom-workspace', 'minimap-titles:border': => @border()
 
+    # Default font to 'ANSI Shadow' if font not set
+    atom.config.set 'atom-minimap-titles.font', 'ANSI Shadow' unless atom.config.get 'atom-minimap-titles.font'
   deactivate: ->
     @subscriptions.dispose()
 
@@ -25,7 +27,7 @@ module.exports = MinimapTitles =
     if editor = atom.workspace.getActiveTextEditor()
 
       figlet = require 'figlet'
-      font = 'ANSI Shadow'
+      font = atom.config.get 'custom-minimap-titles.font'
 
       # get file extension
       fileName = editor.getTitle()


### PR DESCRIPTION
I actually took these lines from [jalenconner/custom-minimap-titles](https://github.com/jalenconner/custom-minimap-titles), so I'm not really the author or whatever (credit goes to @jalenconner for this particular code snippets), but I still think this package, which has support for more comment block formats (and so is the one with the most features) should benefit from even more features, namely this support for custom fonts.
