### PR TITLE
Border and php changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ hello world
 into something like this:
 
 ```
-# ██   ██ ███████ ██      ██       ██████      ██     ██  ██████  ██████  ██      ██████  
+# ██   ██ ███████ ██      ██       ██████      ██     ██  ██████  ██████  ██      ██████
 # ██   ██ ██      ██      ██      ██    ██     ██     ██ ██    ██ ██   ██ ██      ██   ██
 # ███████ █████   ██      ██      ██    ██     ██  █  ██ ██    ██ ██████  ██      ██   ██
 # ██   ██ ██      ██      ██      ██    ██     ██ ███ ██ ██    ██ ██   ██ ██      ██   ██
@@ -60,10 +60,12 @@ To convert text, select the text you wish to convert, and do **any** of the foll
 To create comment borders around text to help distinguish sections in the minimap do the following:
 - Select _Packages_ -> _Minimap Titles_ -> _Toggle Comment Borders_ from the main menu
 - Run the Convert command on your text as detailed above
+- This state is persisted to `atom-minimap-titles.borderOn`
 
 To set a custom font, set `atom-minimap-titles.font` in your atom config file, as such:
 ```
 "atom-minimap-titles":
+  borderOn: true
   font: "Colossal"
 ```
 See existing fonts in the [figlet font database](http://www.figlet.org/fontdb.cgi).

--- a/lib/minimap-titles.coffee
+++ b/lib/minimap-titles.coffee
@@ -3,7 +3,6 @@
 module.exports = MinimapTitles =
   subscriptions: null
   borderOn: false
-  preferredLineLength: 0
   activate: (state) ->
 
     #@borderOn = false
@@ -36,7 +35,7 @@ module.exports = MinimapTitles =
 
       # get multi-cursor selections
       selections = editor.getSelections()
-      @preferredLineLength = atom.config.get('editor.preferredLineLength')
+      preferredLineLength = atom.config.get('editor.preferredLineLength')
       for selection in selections
         do (selection, @borderOn, @preferredLineLength) ->
           if selection.isEmpty()

--- a/lib/minimap-titles.coffee
+++ b/lib/minimap-titles.coffee
@@ -2,10 +2,10 @@
 
 module.exports = MinimapTitles =
   subscriptions: null
-  borderOn: false
+
+  borderOn: true
   activate: (state) ->
 
-    #@borderOn = false
     # Events subscribed to in atom's system can be
     # easily cleaned up with a CompositeDisposable
     @subscriptions = new CompositeDisposable
@@ -16,11 +16,15 @@ module.exports = MinimapTitles =
 
     # Default font to 'ANSI Shadow' if font not set
     atom.config.set 'atom-minimap-titles.font', 'ANSI Shadow' unless atom.config.get 'atom-minimap-titles.font'
+    atom.config.set 'atom-minimap-titles.borderOn', true unless atom.config.get 'atom-minimap-titles.borderOn'
+    @borderOn = atom.config.get 'atom-minimap-titles.borderOn'
+
   deactivate: ->
     @subscriptions.dispose()
 
   border: ->
     @borderOn = not @borderOn
+    atom.config.set 'atom-minimap-titles.borderOn', @borderOn
 
   convert: ->
     if editor = atom.workspace.getActiveTextEditor()

--- a/lib/minimap-titles.coffee
+++ b/lib/minimap-titles.coffee
@@ -95,12 +95,11 @@ module.exports = MinimapTitles =
                 when 'php'
                   if not @borderOn
                     preferredLineLength = 3
-                  commentStart = '/**' + Array(preferredLineLength-3).join('*') + '\n
-                  \t * Block comment\n
-                  \t *\n
-                  \t * @param type\n
-                  \t * @return void\n'
-                  commentEnd = '\n' + Array(preferredLineLength-2).join('*') + '*/\n\t'
+                  commentStart = '/**' + Array(preferredLineLength-3).join('*') + '\n'
+                  # add '* ' to the beginning of each line
+                  art = art.replace /^/, "* "
+                  art = art.replace /\n/g, "\n* "
+                  commentEnd = '\n' + Array(preferredLineLength-2).join('*') + '*/\n'
 
                 when 'vb','vbs'
                   commentStart = ''

--- a/lib/minimap-titles.coffee
+++ b/lib/minimap-titles.coffee
@@ -123,7 +123,7 @@ module.exports = MinimapTitles =
                   commentEnd = '\n' + Array(preferredLineLength-2).join('*') + '*/\n'
 
               selection.insertText(
-                "#{commentStart+art+commentEnd}\n",
+                "#{commentStart+art+commentEnd}",
                 {
                   select: true,
                   autoIndent: true


### PR DESCRIPTION
This PR fixes a bug that prevents borders from being added when the option is selected. It also maintains your border selection when atom is closed and reopened.

This PR modifies the behavior when adding titles to `.php` files.

------------

The PHP titles added an unexpected comment and the art variable wasn't prefixed with an astricks. 

To duplicate the previous commenting behavior in PHP files add this to your atom `snippets.cson`:

    '.text.php':
        'PDoc':
          'prefix': 'pdoc'
          'body':"""
    /**
    * Block Comment
    *
    * @param type
    * @return void
    */
    """